### PR TITLE
Fix hooks dir refers to pre-commit-hooks dir instead of crate that is using this

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,9 @@ license = "MIT"
 repository = "https://github.com/nentgroup/pre-commit-hooks"
 readme = "README.md"
 
+[package.metadata.precommit]
+# Add your pre-commit configuration here.
+# This section is needed when using this pre-commit-hooks.
+
 [build-dependencies]
 toml = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joe Grund <grundjoseph@gmail.com>", "Seto Elkahfi <setoelkahfi@gmail
 build = "build.rs"
 description = "Reads hooks metadata from Cargo.toml and executes on commit. Works with workspace format."
 license = "MIT"
-repository = "https://github.com/setoelkahfi/pre-commit-hooks"
+repository = "https://github.com/nentgroup/pre-commit-hooks"
 readme = "README.md"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pre-commit-hooks"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Joe Grund <grundjoseph@gmail.com>", "Seto Elkahfi <setoelkahfi@gmail.com>"]
 build = "build.rs"
 description = "Reads hooks metadata from Cargo.toml and executes on commit. Works with workspace format."

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # pre-commit-hooks
 
-Reads hooks metadata from Cargo.toml and executes on commit. A forked from unmaintained [pre-commit](https://github.com/rustation/pre-commit).
+Reads hooks metadata from `Cargo.toml` and executes on commit. A forked from unmaintained [pre-commit](https://github.com/rustation/pre-commit).
 
 
 ### Installing
 
 ```
 [dependencies]
-pre-commit-hooks = "0.1"
+pre-commit-hooks = "0.3"
 ```
 
 For a workspace-based setup, one only need to add it in one of the package dependency, usually the main package (if any). This is because the pre-commit applies to the whole project.
@@ -25,7 +25,7 @@ sort = "cargo sort"
 Or, if you're ussing workspace:
 ```
 [workspace.metadata.precommit]
-fmt = "cargo fmt -- --write-mode diff 2>&1"
+fmt = "cargo fmt"
 sort = "cargo sort -w"
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::{env, fs, io, path};
+use std::{env, fs, io};
 
 fn main() {
     match setup_pre_commit_hooks() {
@@ -31,7 +30,9 @@ fn find_crate_root(p: &Path) -> io::Result<PathBuf> {
             let mut f = fs::File::open(manifest)?;
             let mut s = String::new();
             f.read_to_string(&mut s)?;
-            if s.contains("[package.metadata.precommit]") || s.contains("[workspace.metadata.precommit]") {
+            if s.contains("[package.metadata.precommit]")
+                || s.contains("[workspace.metadata.precommit]")
+            {
                 println!("Found pre-commit hooks metadata.");
                 return Ok(current);
             }

--- a/build.rs
+++ b/build.rs
@@ -24,36 +24,41 @@ fn find_crate_root(p: &Path) -> io::Result<PathBuf> {
         .args(["metadata", "--format-version=1", "--no-deps"])
         .output()?;
 
+    print!("cargo metadata stdout: ");
+
     if meta.status.success() {
         let output = String::from_utf8_lossy(&meta.stdout);
+        println!("{}", output);
         let path = if let Some(path) = output.split(r#"workspace_root":""#).nth(1) {
             path
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "couldn't find crate root",
+                "Couldn't find crate root",
             ));
         };
+        print!("Found path: {}", path);
         let path = if let Some(path) = path.split('"').next() {
             path
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "couldn't find crate root",
+                "Couldn't find crate root",
             ));
         };
         let path = path::Path::new(path);
+        print!("Found path: {}", path.display());
         Ok(path.to_path_buf())
     } else {
         Err(io::Error::new(
             io::ErrorKind::Other,
-            "couldn't find crate root",
+            "Couldn't find crate root",
         ))
     }
 }
 
 fn setup_pre_commit_hooks() -> io::Result<()> {
-    let out = &env::var("OUT_DIR").unwrap();
+    let out: &String = &env::var("OUT_DIR").unwrap();
     let p = Path::new(out);
     let root = find_crate_root(p)?;
     let mut f = fs::File::open(root.join("Cargo.toml"))?;
@@ -69,7 +74,7 @@ fn setup_pre_commit_hooks() -> io::Result<()> {
         return Ok(());
     }
 
-    let pre_commit = hooks_dir.join("pre-commit");
+    let pre_commit: PathBuf = hooks_dir.join("pre-commit");
 
     let mut f = File::create(&pre_commit)?;
 


### PR DESCRIPTION
We can simply traverse up the OUT_DIR path until we find the `metadata.precommit`.